### PR TITLE
Ensure these strings are using translation functions too

### DIFF
--- a/frontend-uploader.php
+++ b/frontend-uploader.php
@@ -673,7 +673,7 @@ class Frontend_Uploader {
 			$file_desc = __( 'Your Photo', 'frontend-uploader' );
 			$submit_button = __( 'Submit', 'frontend-uploader' );
 
-			echo do_shortcode ( '[input type="text" name="post_title" id="ug_post_title" description="Title (Required)" class="required"]' );
+			echo do_shortcode ( '[input type="text" name="post_title" id="ug_post_title" description="' . __( 'Title (Required)', 'frontend-uploader' ) . '" class="required"]' );
 
 			// here we select the different fields based on the form layout to allow for different types
 			// of uploads (only a file, only a post or a file and post)
@@ -687,10 +687,10 @@ class Frontend_Uploader {
 								[input type="file" name="photo" id="ug_photo" class="required" description="'. $file_desc .'" multiple=""]' );
 
 			if ( isset( $this->settings['show_author'] )  && $this->settings['show_author'] )
-				echo do_shortcode ( '[input type="text" name="post_author" id="ug_post_author" description="Author" class=""]' );
+				echo do_shortcode ( '[input type="text" name="post_author" id="ug_post_author" description="' . __( 'Author', 'frontend-uploader' ) . '" class=""]' );
 
 			if ( $form_layout=="post_image" or $form_layout=="image" )
-				echo do_shortcode ( '[input type="text" name="post_credit" id="ug_post_credit" description="Credit" class=""]' );
+				echo do_shortcode ( '[input type="text" name="post_credit" id="ug_post_credit" description="' . __( 'Credit', 'frontend-uploader' ) . '" class=""]' );
 
 			echo do_shortcode ( '[input type="submit" class="btn" value="'. $submit_button .'"]' );
 


### PR DESCRIPTION
On http://journalmetro.com/metro-flirt-envoyer/, the labels associated with the fields aren't being translated. This pull request fixes the translation of 'Author' but not "Title (Required)" or "Description (Required)".

Any idea why that might be the case? I suspect it might be the parens in the string.
