### PR TITLE
Use `wp_enqueue_media()` to enqueue admin assets

### DIFF
--- a/frontend-uploader.php
+++ b/frontend-uploader.php
@@ -1182,7 +1182,7 @@ class Frontend_Uploader {
 	 * Enqueue scripts for admin
 	 */
 	function admin_enqueue_scripts() {
-		wp_enqueue_script( 'media', array( 'jquery' ) );
+		wp_enqueue_media();
 	}
 
 	/**


### PR DESCRIPTION
Manually enqueueing media will occasionally result in conflicts with some plugins (like Co-Authors Plus), which will lead to half-loaded Javascript in wp-admin. Using `wp_enqueue_media()` ensures all assets are displayed as required to guarantee peace, harmony, and synergy amongst plugins.
