### PR TITLE
Use proper return value check for get_post call in Frontend_Uploader::approve_post

### DIFF
--- a/frontend-uploader.php
+++ b/frontend-uploader.php
@@ -776,7 +776,7 @@ class Frontend_Uploader {
 
 		$post = get_post( $_GET['id'] );
 
-		if ( !is_wp_error( $post ) ) {
+		if ( is_object( $post ) ) {
 			$post->post_status = 'publish';
 			wp_update_post( $post );
 


### PR DESCRIPTION
The `get_post`, with default value for $output param, returns either an object of `WP_Post` class or null, never an object of WP_Error. See: https://developer.wordpress.org/reference/functions/get_post/ for details. Thus `is_wp_error` is not a proper check for return value.

This commit addresses the issue by replacing `!is_wp_error( $post )` by `is_object( $post )` conditional.

Fixes #74