### PR TITLE
Fix array_unshift() TypeError on PHP 8 when sideload fails

### DIFF
--- a/frontend-uploader.php
+++ b/frontend-uploader.php
@@ -1426,6 +1426,7 @@ class Frontend_Uploader {
 			foreach ( (array) $details as $single_error ) {
 				if ( isset( $map[ $error ]['format'] ) ) {
 					// Prepend the array with error message
+					$single_error = (array) $single_error;
 					array_unshift( $single_error, $map[ $error ]['text'] );
 					$message = vsprintf( $map[ $error ]['format'], $single_error );
 				} else {


### PR DESCRIPTION
## Summary

- Fixes a fatal `TypeError` on PHP 8+ when `media_handle_sideload` returns a `WP_Error` during file upload
- The `fu-error-media` error is stored as a bare string (filename) in one code path (line 346) but `_display_errors()` passes it to `array_unshift()` which expects an array
- Adds an `(array)` cast before the `array_unshift()` call so both error formats are handled consistently

## Root Cause

Two code paths store `fu-error-media` errors in different formats:
- **Line 296** (file `$_FILES` error): stores `array( 'name' => ..., 'code' => ... )`
- **Line 346** (sideload `WP_Error`): stores a bare string (`$k['name']`)

On PHP 7 the type mismatch produced a warning; on PHP 8+ it's a fatal `TypeError`.

## Test plan

- [ ] Upload a file that fails at the `media_handle_sideload` stage (e.g. a `.dng` file) and confirm the error message displays instead of a fatal error

🤖 Generated with [Claude Code](https://claude.com/claude-code)