### PR TITLE
Improve input handling in upload and moderation paths

### DIFF
--- a/frontend-uploader.php
+++ b/frontend-uploader.php
@@ -502,18 +502,21 @@ class Frontend_Uploader {
 			}
 		}
 
-		if ( isset( $_POST['caption'] ) ) {
-			$post_title = sanitize_text_field( wp_unslash( $_POST['caption'] ) );
-		} elseif ( isset( $_POST['post_title'] ) ) {
-			$post_title = sanitize_text_field( wp_unslash( $_POST['post_title'] ) );
+		// phpcs:disable WordPress.Security.ValidatedSanitizedInput.MissingUnslash -- wp_insert_post() is "Expected_slashed (everything!)" and unslashes the array itself.
+		if ( isset( $_POST['caption'] ) && is_scalar( $_POST['caption'] ) ) {
+			$post_title = sanitize_text_field( $_POST['caption'] );
+		} elseif ( isset( $_POST['post_title'] ) && is_scalar( $_POST['post_title'] ) ) {
+			$post_title = sanitize_text_field( $_POST['post_title'] );
 		} else {
 			$post_title = '';
 		}
+		// phpcs:enable WordPress.Security.ValidatedSanitizedInput.MissingUnslash
 
 		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, WordPress.Security.ValidatedSanitizedInput.MissingUnslash -- wp_filter_post_kses() sanitizes and re-slashes; wp_insert_post() expects slashed data.
 		$post_content = isset( $_POST['post_content'] ) && is_scalar( $_POST['post_content'] ) ? wp_filter_post_kses( (string) $_POST['post_content'] ) : '';
 
-		$submitted_post_type = isset( $_POST['post_type'] ) && is_scalar( $_POST['post_type'] ) ? sanitize_key( wp_unslash( $_POST['post_type'] ) ) : '';
+		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.MissingUnslash -- see above; sanitize_key() strips backslashes regardless.
+		$submitted_post_type = isset( $_POST['post_type'] ) && is_scalar( $_POST['post_type'] ) ? sanitize_key( $_POST['post_type'] ) : '';
 
 		// Construct post array;
 		$post_array = array(

--- a/frontend-uploader.php
+++ b/frontend-uploader.php
@@ -305,15 +305,26 @@ class Frontend_Uploader {
 	 */
 	function _upload_files( $post_id = 0 ) {
 		$media_ids = $errors = array();
+
+		/*
+		 * Callers read $result['success'] unconditionally, so the bails below return the same
+		 * shape as the normal path. No files is not an error, matching $success below.
+		 */
+		$no_files = array(
+			'success'   => true,
+			'media_ids' => array(),
+			'errors'    => array(),
+		);
+
 		// Bail if there are no files
 		if ( empty( $_FILES ) )
-			return array();
+			return $no_files;
 
 		// File field name could be user defined, so we just get the first file
 		$files = current( $_FILES );
 
 		if ( ! isset( $files['name'] ) ) {
-			return array();
+			return $no_files;
 		}
 
 		$fields = array( 'name', 'type', 'tmp_name', 'error', 'size' );
@@ -504,7 +515,7 @@ class Frontend_Uploader {
 		}
 
 		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, WordPress.Security.ValidatedSanitizedInput.MissingUnslash -- wp_filter_post_kses() sanitizes and re-slashes; wp_insert_post() expects slashed data.
-		$post_content = isset( $_POST['post_content'] ) ? wp_filter_post_kses( $_POST['post_content'] ) : '';
+		$post_content = isset( $_POST['post_content'] ) && is_scalar( $_POST['post_content'] ) ? wp_filter_post_kses( (string) $_POST['post_content'] ) : '';
 
 		$submitted_post_type = isset( $_POST['post_type'] ) && is_scalar( $_POST['post_type'] ) ? sanitize_key( wp_unslash( $_POST['post_type'] ) ) : '';
 
@@ -518,7 +529,8 @@ class Frontend_Uploader {
 		);
 
 		// Stored as meta only: resolving this to a user would let anyone post as an administrator.
-		$author = isset( $_POST['post_author'] ) ? sanitize_text_field( $_POST['post_author'] ) : '';
+		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.MissingUnslash -- add_post_meta() unslashes; unslashing here too would mangle names like O'Brien.
+		$author = isset( $_POST['post_author'] ) && is_scalar( $_POST['post_author'] ) ? sanitize_text_field( $_POST['post_author'] ) : '';
 
 		$post_array = apply_filters( 'fu_before_create_post', $post_array );
 
@@ -606,7 +618,7 @@ class Frontend_Uploader {
 		$hash              = isset( $_POST['ff'] ) && is_scalar( $_POST['ff'] ) ? sanitize_text_field( wp_unslash( $_POST['ff'] ) ) : '';
 		$this->form_fields = !empty( $this->form_fields ) ? $this->form_fields : $this->_get_fields_for_form( $form_post_id, $hash );
 
-		$layout = isset( $_POST['form_layout'] ) && ! empty( $_POST['form_layout'] ) ? sanitize_text_field( $_POST['form_layout'] ) : 'image';
+		$layout = isset( $_POST['form_layout'] ) && is_scalar( $_POST['form_layout'] ) && ! empty( $_POST['form_layout'] ) ? sanitize_text_field( wp_unslash( $_POST['form_layout'] ) ) : 'image';
 
 		/**
 		 * Utility hook 'fu_should_process_content_upload': maybe terminate upload early (useful for Akismet integration, etc)

--- a/frontend-uploader.php
+++ b/frontend-uploader.php
@@ -864,7 +864,7 @@ class Frontend_Uploader {
 	 */
 	function add_menu_items() {
 		add_media_page( __( 'Manage UGC', 'frontend-uploader' ), __( 'Manage UGC', 'frontend-uploader' ), $this->manage_permissions, 'manage_frontend_uploader', array( $this, 'admin_list' ) );
-		foreach ( (array) $this->settings['enabled_post_types'] as $cpt ) {
+		foreach ( $this->get_enabled_post_types() as $cpt ) {
 			if ( $cpt === 'post' ) {
 				add_posts_page( __( 'Manage UGC Posts', 'frontend-uploader' ), __( 'Manage UGC', 'frontend-uploader' ), $this->manage_permissions, 'manage_frontend_uploader_posts', array( $this, 'admin_posts_list' ) );
 				continue;
@@ -1303,7 +1303,7 @@ class Frontend_Uploader {
 
 		// Not via shortcode_content_parser(), which would put it in the field map and change the `ff` hash.
 		if ( 0 !== $post_id ) {
-			wp_nonce_field( FU_PARENT_NONCE . '-' . $post_id, 'fu_parent_nonce' );
+			wp_nonce_field( FU_PARENT_NONCE . '-' . $post_id, 'fu_parent_nonce', false );
 		}
 
 		if ( isset( $category ) && 0 !== (int) $category ) {

--- a/frontend-uploader.php
+++ b/frontend-uploader.php
@@ -306,10 +306,6 @@ class Frontend_Uploader {
 	function _upload_files( $post_id = 0 ) {
 		$media_ids = $errors = array();
 
-		/*
-		 * Callers read $result['success'] unconditionally, so the bails below return the same
-		 * shape as the normal path. No files is not an error, matching $success below.
-		 */
 		$no_files = array(
 			'success'   => true,
 			'media_ids' => array(),

--- a/frontend-uploader.php
+++ b/frontend-uploader.php
@@ -148,8 +148,8 @@ class Frontend_Uploader {
 	 * Handle MIME-types:
 	 *
 	 * First we check what's in the plugin setting (if there's nothing we're falling back to Core list)
-	 * If we're falling back to core value, make sure to remove HTML and JS files.
-	 * Then we also explicitly try to remove any variant of PHP, just in case.
+	 * Entries are re-mapped to core's own extension regex => mime-type pair, then filtered by
+	 * mime-type value.
 	 *
 	 * After that we pass the value to the filter,
 	 * so if somebody really wants to shoot in the foot they can do so.
@@ -157,27 +157,63 @@ class Frontend_Uploader {
 	 * @return array the list of allowed for uploading mime types
 	 */
 	function _get_mime_types() {
-		// $mime_types_orig is needed to re-map the values from the settings lib structure to core WP extension regex => mime-type format.
-		remove_filter( 'upload_mimes', [ $this, '_get_mime_types' ], 999 );
+		// Only re-attach when it was attached, or calling this directly applies the list site-wide.
+		$was_filtering = remove_filter( 'upload_mimes', array( $this, '_get_mime_types' ), 999 );
 		$mime_types = $mime_types_orig = get_allowed_mime_types();
-		add_filter( 'upload_mimes', [ $this, '_get_mime_types' ], 999 );
+		if ( $was_filtering ) {
+			add_filter( 'upload_mimes', array( $this, '_get_mime_types' ), 999 );
+		}
 
 		$enabled = isset( $this->settings['enabled_files'] ) && is_array( $this->settings['enabled_files'] ) && $this->settings['enabled_files'] ? $this->settings['enabled_files'] : $mime_types;
 
+		// Per extension, not a substring test: 'phtml' does not contain 'php'.
+		$executable = '/^(php\d*|phps|pht|phtml?|phar|shtml?|cgi|pl|htaccess|htpasswd)$/i';
+
 		foreach ( $enabled as $ext_key => $mime ) {
-			// Check for PHP.
-			if ( false !== strpos( $mime, 'php' ) ) {
+			$is_executable = false;
+
+			foreach ( explode( '|', (string) $ext_key ) as $extension ) {
+				if ( preg_match( $executable, trim( $extension ) ) ) {
+					$is_executable = true;
+					break;
+				}
+			}
+
+			if ( $is_executable ) {
 				unset( $enabled[ $ext_key ] );
 				trigger_error( __( "Frontend Uploader doesn't support PHP uploads for security reasons", 'frontend-uploader' ) );
+				continue;
+			}
+
+			if ( ! isset( $mime_types_orig[ $ext_key ] ) ) {
+				unset( $enabled[ $ext_key ] );
+				continue;
 			}
 
 			// We need to re-map the value from our settings to the proper MIME-type instead of regex key for mime check to work correctly.
 			$enabled[ $ext_key ] = $mime_types_orig[ $ext_key ];
 		}
 
-		unset( $enabled['htm|html'] );
-		unset( $enabled['js'] );
-		unset( $enabled['svg|svgz'] );
+		// By mime-type, not key: core ships no 'svg' entry, so a key-based unset() catches nothing.
+		$blocked = array(
+			'text/html',
+			'application/xhtml+xml',
+			'image/svg+xml',
+			'application/javascript',
+			'text/javascript',
+			'application/x-javascript',
+			'application/x-shockwave-flash',
+			'application/x-msdownload',
+			'application/x-httpd-php',
+			'application/x-httpd-php-source',
+			'text/x-php',
+		);
+
+		foreach ( $enabled as $ext_key => $mime ) {
+			if ( in_array( $mime, $blocked, true ) ) {
+				unset( $enabled[ $ext_key ] );
+			}
+		}
 
 		/**
 		 * Configuration filter: fu_allowed_mime_types should return array of allowed mime types (see readme)
@@ -268,9 +304,6 @@ class Frontend_Uploader {
 	 * @return array Combined result of media ids and errors if any
 	 */
 	function _upload_files( $post_id = 0 ) {
-		// Only filter mimes just before the upload.
-		add_filter( 'upload_mimes', array( $this, '_get_mime_types' ), 999 );
-
 		$media_ids = $errors = array();
 		// Bail if there are no files
 		if ( empty( $_FILES ) )
@@ -279,18 +312,38 @@ class Frontend_Uploader {
 		// File field name could be user defined, so we just get the first file
 		$files = current( $_FILES );
 
-		// There can be multiple files
-		// So we need to iterate over each of the files to process
-		for ( $i = 0; $i < count( $files['name'] ); $i++ ) {
-			$fields = array( 'name', 'type', 'tmp_name', 'error', 'size' );
+		if ( ! isset( $files['name'] ) ) {
+			return array();
+		}
+
+		$fields = array( 'name', 'type', 'tmp_name', 'error', 'size' );
+
+		// A field posted without [] yields scalars rather than arrays.
+		if ( ! is_array( $files['name'] ) ) {
 			foreach ( $fields as $field ) {
-				$k[$field] = $files[$field][$i];
+				$files[ $field ] = array( isset( $files[ $field ] ) ? $files[ $field ] : '' );
+			}
+		}
+
+		$file_count = count( $files['name'] );
+
+		// Attached here rather than on entry: the bails above must not outrun the removal below.
+		add_filter( 'upload_mimes', array( $this, '_get_mime_types' ), 999 );
+
+		for ( $i = 0; $i < $file_count; $i++ ) {
+			$k = array();
+			foreach ( $fields as $field ) {
+				$k[ $field ] = isset( $files[ $field ][ $i ] ) ? $files[ $field ][ $i ] : '';
+			}
+
+			// A nested field (name="a[b][]") leaves arrays here, with nothing to sideload.
+			if ( ! is_string( $k['name'] ) || ! is_string( $k['tmp_name'] ) ) {
+				continue;
 			}
 
 			$k['name'] = sanitize_file_name( $k['name'] );
 
-			//
-			if ( $k['error'] === 4 ) {
+			if ( UPLOAD_ERR_NO_FILE === (int) $k['error'] ) {
 				continue;
 			}
 
@@ -348,6 +401,8 @@ class Frontend_Uploader {
 			else
 				$errors['fu-error-media'][] = $k['name'];
 		}
+
+		remove_filter( 'upload_mimes', array( $this, '_get_mime_types' ), 999 );
 
 		/**
 		 * $success determines the rest of upload flow
@@ -427,41 +482,43 @@ class Frontend_Uploader {
 	 * @since 0.4
 	 */
 	function _upload_post() {
+		// phpcs:disable WordPress.Security.NonceVerification.Missing -- upload_content() verifies FU_NONCE before dispatching here.
 		$errors = array();
 		$success = true;
 
-		// Sanitize category if present in request
-		// Allow to supply comma-separated category ids
 		$category = array();
-		if ( isset( $_POST['post_category'] ) ) {
-			foreach ( explode( ',', $_POST['post_category'] ) as $cat_id ) {
+		if ( isset( $_POST['post_category'] ) && is_scalar( $_POST['post_category'] ) ) {
+			$submitted_categories = sanitize_text_field( wp_unslash( $_POST['post_category'] ) );
+
+			foreach ( explode( ',', $submitted_categories ) as $cat_id ) {
 				$category[] = (int) $cat_id;
 			}
 		}
 
-		$post_title = isset( $_POST['caption'] ) ? sanitize_text_field( $_POST['caption'] ) : sanitize_text_field( $_POST['post_title'] );
+		if ( isset( $_POST['caption'] ) ) {
+			$post_title = sanitize_text_field( wp_unslash( $_POST['caption'] ) );
+		} elseif ( isset( $_POST['post_title'] ) ) {
+			$post_title = sanitize_text_field( wp_unslash( $_POST['post_title'] ) );
+		} else {
+			$post_title = '';
+		}
+
+		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, WordPress.Security.ValidatedSanitizedInput.MissingUnslash -- wp_filter_post_kses() sanitizes and re-slashes; wp_insert_post() expects slashed data.
+		$post_content = isset( $_POST['post_content'] ) ? wp_filter_post_kses( $_POST['post_content'] ) : '';
+
+		$submitted_post_type = isset( $_POST['post_type'] ) && is_scalar( $_POST['post_type'] ) ? sanitize_key( wp_unslash( $_POST['post_type'] ) ) : '';
 
 		// Construct post array;
 		$post_array = array(
-			'post_type' => isset( $_POST['post_type'] ) && $this->is_allowed_post_type( $_POST['post_type'] ) ? sanitize_key( $_POST['post_type'] ) : 'post',
-			'post_title' => $post_title ? $post_title : __( 'Untitled post submission', 'frontend-uploader' ),
-			'post_content' => wp_filter_post_kses( $_POST['post_content'] ),
-			'post_status' => $this->_is_public() ? 'publish' : 'private',
+			'post_type'     => $this->is_allowed_post_type( $submitted_post_type ) ? $submitted_post_type : 'post',
+			'post_title'    => $post_title ? $post_title : __( 'Untitled post submission', 'frontend-uploader' ),
+			'post_content'  => $post_content,
+			'post_status'   => $this->_is_public() ? 'publish' : 'private',
 			'post_category' => $category,
 		);
 
+		// Stored as meta only: resolving this to a user would let anyone post as an administrator.
 		$author = isset( $_POST['post_author'] ) ? sanitize_text_field( $_POST['post_author'] ) : '';
-
-		if ( $author ) {
-			$users = get_users( array(
-				'search' => $author,
-				'fields' => 'ID'
-			) );
-
-			if ( isset( $users[0] ) ) {
-				$post_array['post_author'] = (int) $users[0];
-			}
-		}
 
 		$post_array = apply_filters( 'fu_before_create_post', $post_array );
 
@@ -477,11 +534,11 @@ class Frontend_Uploader {
 			do_action( 'fu_after_create_post', $post_id );
 
 			$this->_save_post_meta_fields( $post_id );
-			// If the author name is not in registered users
-			// Save the author name if it was filled and post was created successfully
 			if ( $author )
 				add_post_meta( $post_id, 'author_name', $author );
 		}
+
+		// phpcs:enable WordPress.Security.NonceVerification.Missing
 
 		return array( 'success' => $success, 'post_id' => $post_id, 'errors' => $errors );
 	}
@@ -521,19 +578,32 @@ class Frontend_Uploader {
 		$fields = $result = array();
 
 		// Bail if something fishy is going on
-		if ( !wp_verify_nonce( $_POST['fu_nonce'], FU_NONCE ) ) {
-			wp_safe_redirect( add_query_arg( array( 'response' => 'fu-error', 'errors' =>  array( 'fu-nonce-failure' => 1 ) ), wp_get_referer() ) );
+		$fu_nonce = isset( $_POST['fu_nonce'] ) ? sanitize_text_field( wp_unslash( $_POST['fu_nonce'] ) ) : '';
+		if ( ! wp_verify_nonce( $fu_nonce, FU_NONCE ) ) {
+			$nonce_error = array(
+				'response' => 'fu-error',
+				'errors'   => array( 'fu-nonce-failure' => 1 ),
+			);
+			wp_safe_redirect( add_query_arg( $nonce_error, wp_get_referer() ) );
 			exit;
 		}
 
 		// Bail if supplied post type is not allowed
-		if ( isset( $_POST['post_type'] ) && ! $this->is_allowed_post_type( sanitize_key( $_POST['post_type'] ) ) ) {
-			wp_safe_redirect( add_query_arg( array( 'response' => 'fu-error', 'errors' => array( 'fu-disallowed-post-type' => sanitize_key( $_POST['post_type'] ) ) ), wp_get_referer() ) );
-			exit;
+		if ( isset( $_POST['post_type'] ) ) {
+			$submitted_post_type = is_scalar( $_POST['post_type'] ) ? sanitize_key( wp_unslash( $_POST['post_type'] ) ) : '';
+
+			if ( ! $this->is_allowed_post_type( $submitted_post_type ) ) {
+				$post_type_error = array(
+					'response' => 'fu-error',
+					'errors'   => array( 'fu-disallowed-post-type' => $submitted_post_type ),
+				);
+				wp_safe_redirect( add_query_arg( $post_type_error, wp_get_referer() ) );
+				exit;
+			}
 		}
 
-		$form_post_id = isset( $_POST['form_post_id'] ) ? (int) $_POST['form_post_id'] : 0;
-		$hash = sanitize_text_field( $_POST['ff'] );
+		$form_post_id      = isset( $_POST['form_post_id'] ) ? (int) $_POST['form_post_id'] : 0;
+		$hash              = isset( $_POST['ff'] ) && is_scalar( $_POST['ff'] ) ? sanitize_text_field( wp_unslash( $_POST['ff'] ) ) : '';
 		$this->form_fields = !empty( $this->form_fields ) ? $this->form_fields : $this->_get_fields_for_form( $form_post_id, $hash );
 
 		$layout = isset( $_POST['form_layout'] ) && ! empty( $_POST['form_layout'] ) ? sanitize_text_field( $_POST['form_layout'] ) : 'image';
@@ -768,7 +838,7 @@ class Frontend_Uploader {
 	 * @return boolean
 	 */
 	function is_allowed_post_type( $post_type = 'post' ) {
-		return in_array( $post_type, $this->settings['enabled_post_types'], true );
+		return in_array( $post_type, $this->get_enabled_post_types(), true );
 	}
 
 	/**
@@ -840,7 +910,7 @@ class Frontend_Uploader {
 	 */
 	function approve_post() {
 		// check for permissions and id
-		$post = $this->authorize_ugc_action( 'approve-post', 'edit_post', $this->get_moderatable_post_types() );
+		$post = $this->authorize_ugc_action( 'approve-post', 'edit_post', $this->get_enabled_post_types() );
 
 		// Publishing is its own right; the 'publish_post' meta cap is WP 6.1+, so check the post type's.
 		if ( false !== $post ) {
@@ -886,7 +956,7 @@ class Frontend_Uploader {
 	 */
 	function delete_post() {
 		$args = array();
-		$post = $this->authorize_ugc_action( 'delete', 'delete_post', array_merge( array( 'attachment' ), $this->get_moderatable_post_types() ) );
+		$post = $this->authorize_ugc_action( 'delete', 'delete_post', array_merge( array( 'attachment' ), $this->get_enabled_post_types() ) );
 
 		if ( false !== $post && wp_delete_post( $post->ID, true ) ) {
 			$args['deleted'] = 1;
@@ -947,13 +1017,16 @@ class Frontend_Uploader {
 	}
 
 	/**
-	 * Post types the plugin moderates
+	 * Post types the plugin accepts submissions for and moderates
+	 *
+	 * Normalizes both shapes the setting takes: key => label before the settings page is
+	 * saved, key => key after.
 	 *
 	 * @since 1.3.5
 	 *
 	 * @return array Registered post type names.
 	 */
-	private function get_moderatable_post_types() {
+	private function get_enabled_post_types() {
 		$enabled = array_filter( (array) $this->settings['enabled_post_types'] );
 		$keys    = array_keys( $enabled );
 		$names   = $keys && is_string( $keys[0] ) ? $keys : array_values( $enabled );
@@ -1024,7 +1097,7 @@ class Frontend_Uploader {
 		if ( $type === 'hidden' )
 			return $input;
 
-		$label = $this->html->element( 'label', $description , array( 'for' => $id ), false );
+		$label = $this->html->element( 'label', $description, array( 'for' => $id ) );
 
 		$help = isset( $help ) && $help ? $this->html->element( 'p', sanitize_text_field( $help ), array( 'class' => 'ugc-help' ) ) : '';
 
@@ -1042,7 +1115,7 @@ class Frontend_Uploader {
 
 		$help = isset( $help ) && $help ? $this->html->element( 'p', sanitize_text_field( $help ), array( 'class' => 'ugc-help' ) ) : '';
 
-		$label = $this->html->element( 'label', $description , array( 'for' => $id ), false );
+		$label = $this->html->element( 'label', $description, array( 'for' => $id ) );
 
 		// Render WYSIWYG textarea
 		if ( $wysiwyg_enabled ) {
@@ -1061,7 +1134,7 @@ class Frontend_Uploader {
 
 		$element = $this->html->element( 'textarea', '', array( 'name' => $name, 'id' => $id, 'class' => $class, 'minlength' => $minlength, 'maxlength' => $maxlength, 'required' => $required ) );
 		// Render plain textarea
-		$label = $this->html->element( 'label', $description, array( 'for' => $id ), false );
+		$label = $this->html->element( 'label', $description, array( 'for' => $id ) );
 
 		return $this->html->element( 'div', $label  . $element . $help, array( 'class' => 'ugc-input-wrapper' ), false );
 	}
@@ -1090,7 +1163,8 @@ class Frontend_Uploader {
 			$options .= $this->html->_checkbox( $name, isset( $kv[1] ) ? $kv[1] : $kv[0], $kv[0], $atts, array() );
 		}
 
-		$description = $label = $this->html->element( 'label', $description, array(), false );
+		$label       = $this->html->element( 'label', $description, array() );
+		$description = $label;
 
 		// Render select field
 		$element = $this->html->element( 'div', $description  . $help . $options, array( 'class' => 'checkbox-wrapper ' . $class ), false );
@@ -1119,7 +1193,7 @@ class Frontend_Uploader {
 		}
 
 		//Render
-		$label = $this->html->element( 'label', $description , array( 'for' => $id ), false );
+		$label = $this->html->element( 'label', $description, array( 'for' => $id ) );
 
 		return $this->html->element( 'div', $label . $help . $options, array( 'class' => 'ugc-input-wrapper ' . $class ), false );
 	}
@@ -1141,11 +1215,11 @@ class Frontend_Uploader {
 			$kv = explode( ":", $option );
 			$caption = isset( $kv[1] ) ? $kv[1] : $kv[0];
 
-			$options .= $this->html->element( 'option', $caption, array( 'value' => $kv[0] ), false );
+			$options .= $this->html->element( 'option', $caption, array( 'value' => $kv[0] ) );
 		}
 
 		//Render select field
-		$label = $this->html->element( 'label', $description , array( 'for' => $id ), false );
+		$label = $this->html->element( 'label', $description, array( 'for' => $id ) );
 
 		$element =$this->html->element( 'select', $options, array(
 			'name' => $name,
@@ -1448,7 +1522,8 @@ class Frontend_Uploader {
 		if ( empty( $res ) || !is_array( $res ) )
 			return;
 
-		array_walk_recursive( $res, 'sanitize_text_field' );
+		// map_deep() returns the sanitized copy; array_walk_recursive() would discard it.
+		$res = map_deep( $res, 'sanitize_text_field' );
 
 		$output = '';
 		$map = apply_filters( 'fu_response_notices', array(
@@ -1527,10 +1602,22 @@ class Frontend_Uploader {
 			// We might have multiple errors of the same type, let's walk through them
 			foreach ( (array) $details as $single_error ) {
 				if ( isset( $map[ $error ]['format'] ) ) {
+					// $errors comes from the query string, so the arg count is attacker-controlled.
+					$single_error = array_map(
+						function ( $arg ) {
+							return is_scalar( $arg ) ? (string) $arg : '';
+						},
+						array_values( (array) $single_error )
+					);
+
 					// Prepend the array with error message
-					$single_error = (array) $single_error;
 					array_unshift( $single_error, $map[ $error ]['text'] );
-					$message = vsprintf( $map[ $error ]['format'], $single_error );
+
+					$arity = preg_match_all( '/%(\d+)\$/', $map[ $error ]['format'], $matches )
+						? max( array_map( 'intval', $matches[1] ) )
+						: 0;
+
+					$message = vsprintf( $map[ $error ]['format'], array_pad( $single_error, $arity, '' ) );
 				} else {
 					$message = $map[ $error ]['text'];
 				}

--- a/frontend-uploader.php
+++ b/frontend-uploader.php
@@ -181,7 +181,14 @@ class Frontend_Uploader {
 
 			if ( $is_executable ) {
 				unset( $enabled[ $ext_key ] );
-				trigger_error( __( "Frontend Uploader doesn't support PHP uploads for security reasons", 'frontend-uploader' ) );
+				// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error -- pre-existing developer notice.
+				trigger_error(
+					sprintf(
+						/* translators: %s: the blocked extension key, e.g. "phtml". */
+						esc_html__( 'Frontend Uploader blocks uploads of executable file types for security reasons: %s', 'frontend-uploader' ),
+						esc_html( $ext_key )
+					)
+				);
 				continue;
 			}
 

--- a/lib/php/class-html-helper.php
+++ b/lib/php/class-html-helper.php
@@ -20,15 +20,16 @@ class Html_Helper {
 	 */
 	function checkboxes( $name = '', $description = '', $data = array(), $checked = array() ) {
 		if ( $name !== '' ) {
-			$name = filter_var( $name, FILTER_SANITIZE_STRING );
-			if ( $description );
-			echo $this->element( 'p', __( $description ) );
+			$name = sanitize_text_field( $name );
+			if ( $description ) {
+				echo wp_kses_post( $this->element( 'p', $description ) );
+			}
 			echo '<input type="hidden" name="' . esc_attr( $name ) .'" value="" />';
 			foreach ( (array) $data as $item ) {
-				$is_checked_attr =  in_array( $item, (array) $checked, true ) ? ' checked="true" ' : '';
-				$item = filter_var( $item, FILTER_SANITIZE_STRING );
+				$is_checked = in_array( $item, (array) $checked, true );
+				$item       = sanitize_text_field( $item );
 				echo '<div class="sm-input-wrapper">';
-				echo '<input type="checkbox" name="' . esc_attr( $name ) . '[]" value="' . esc_attr( $item ) . '" id="' .esc_attr( $name ) . esc_attr( $item )  . '" ' . esc_attr( $is_checked_attr ) . ' />';
+				echo '<input type="checkbox" name="' . esc_attr( $name ) . '[]" value="' . esc_attr( $item ) . '" id="' . esc_attr( $name ) . esc_attr( $item ) . '"' . checked( $is_checked, true, false ) . ' />';
 				echo '<label for="' .esc_attr( $name ) . esc_attr( $item )  . '">' . esc_attr ( $item ) . '</label>';
 				echo '</div>';
 			}
@@ -55,7 +56,7 @@ class Html_Helper {
 		$data = func_get_args();
 		$ret = '';
 		foreach ( $data as $cell )
-			$ret .= $this->element( 'td', $cell, null, false );
+			$ret .= $this->element( 'td', $cell, null );
 		return "<tr>" . $ret . "</tr>\n";
 	}
 
@@ -121,9 +122,12 @@ class Html_Helper {
 		$ret  = '';
 		foreach ( (array) $data as $key => $value ) {
 			$attrs_to_pass = array( 'value' => $key );
-			if ( isset( $attrs[ 'default' ] ) && $key === $attrs[ 'default' ] )
-				$attrs_to_pass[ 'selected' ] = 'selected';
-			$ret .= $this->element( 'option', $value, $attrs_to_pass, false );
+
+			if ( isset( $attrs['default'] ) && $key === $attrs['default'] ) {
+				$attrs_to_pass['selected'] = 'selected';
+			}
+
+			$ret .= $this->element( 'option', $value, $attrs_to_pass );
 		}
 		return '<select name="' . esc_attr( $name ) . '">' . $ret . '</select>';
 	}

--- a/lib/php/class-html-helper.php
+++ b/lib/php/class-html-helper.php
@@ -25,9 +25,12 @@ class Html_Helper {
 				echo wp_kses_post( $this->element( 'p', $description ) );
 			}
 			echo '<input type="hidden" name="' . esc_attr( $name ) .'" value="" />';
+			$checked = array_map( 'sanitize_text_field', (array) $checked );
+
 			foreach ( (array) $data as $item ) {
-				$is_checked = in_array( $item, (array) $checked, true );
+				// Compare after sanitizing, so the checked state matches the value submitted.
 				$item       = sanitize_text_field( $item );
+				$is_checked = in_array( $item, $checked, true );
 				echo '<div class="sm-input-wrapper">';
 				echo '<input type="checkbox" name="' . esc_attr( $name ) . '[]" value="' . esc_attr( $item ) . '" id="' . esc_attr( $name ) . esc_attr( $item ) . '"' . checked( $is_checked, true, false ) . ' />';
 				echo '<label for="' .esc_attr( $name ) . esc_attr( $item )  . '">' . esc_attr ( $item ) . '</label>';


### PR DESCRIPTION
Follow-up hardening and robustness pass over the upload and moderation request paths, in the same vein as #94. Mostly normalization of values that were assumed to be well-formed, plus a few consistency fixes between related code paths.

## Mime-type list

- Filter the enabled list by mime-type **value** rather than extension key. Core ships no `svg` entry, so the previous key-based `unset( $enabled['svg|svgz'] )` from 54c8e36 could only ever match that exact spelling, and third-party registrations use `svg`.
- Match executable extensions per pipe-separated segment against a pattern. A substring test on `php` misses `phtml`, since `phtml` does not contain `php`.
- Skip keys core does not recognize instead of writing `null` into the list. `wp_get_mime_types()` includes `swf`/`exe` while `get_allowed_mime_types()` drops them, so the default settings produced two undefined-key warnings on every request.
- Only re-attach the `upload_mimes` filter when it was attached, and scope it to the sideload loop, so calling `_get_mime_types()` directly does not leave the frontend list applied site-wide.

## Request handling

- Handle a file field posted without `[]` (yields scalars, not arrays) and skip more deeply nested fields; both previously reached `count()`/`sanitize_file_name()` with the wrong type.
- Guard `$_POST` reads in `upload_content()` and `_upload_post()`, and add `wp_unslash()` where it was missing.
- Pad `vsprintf()` arguments to the format's arity. The argument count comes from the query string, and the debug format takes three placeholders.
- Use `map_deep()` in `_display_response_notices()`. `array_walk_recursive()` passes values by value, so the sanitized copy was discarded and the line did nothing.

## Consistency

- `is_allowed_post_type()` and the moderation post-type list now share one normalization helper. The setting holds `key => label` before the settings page is saved and `key => key` after; only the moderation side handled both, so on a default install the submission predicate rejected `post`.
- Record the submitted author name as post meta instead of resolving it against `get_users()` and assigning `post_author`.
- Escape label and option content in the shortcode renderers, matching how the sibling `help` attribute is already handled.
- Tidy a few escaping and dead-code issues in `Html_Helper` (empty `if` statement, `FILTER_SANITIZE_STRING` deprecated in PHP 8.1, an escaped attribute fragment).

## Testing

All modified lines pass `phpcs --standard=WordPress` with zero errors and zero warnings. Behavior was checked with a standalone harness covering the mime remap, the extension pattern, `$_FILES` shape normalization, `vsprintf` arity, and the post-type predicate across all three setting shapes.

The existing suite is a single `test_dummy()` and needs the WP test framework, so it was not run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)