### PR TITLE
Add WordPress.org deploy workflow

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -1,0 +1,25 @@
+# Files and directories that should not ship in the plugin package.
+# Consumed by 10up/action-wordpress-plugin-deploy via rsync --exclude-from.
+#
+# screenshot-*.png are deliberately absent: wp.org serves this plugin's
+# screenshots from trunk, since SVN assets/ holds only the banner.
+
+/.git
+/.github
+/.wordpress-org
+/bin
+/tests
+/node_modules
+/vendor
+
+.distignore
+.gitignore
+.gitattributes
+.travis.yml
+composer.json
+composer.lock
+phpunit.xml
+readme.md
+
+.DS_Store
+Thumbs.db

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,17 +3,6 @@ name: Deploy to WordPress.org
 on:
   release:
     types: [published]
-  workflow_dispatch:
-    inputs:
-      version:
-        description: 'Version to deploy, e.g. 1.3.5. Must match a tag and the readme.txt stable tag.'
-        required: true
-        type: string
-      dry-run:
-        description: 'Run without committing to SVN'
-        required: false
-        default: true
-        type: boolean
 
 jobs:
   deploy:
@@ -23,17 +12,11 @@ jobs:
     steps:
       - name: Check out
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.version || github.ref }}
 
       - name: Deploy to WordPress.org
         uses: 10up/action-wordpress-plugin-deploy@54bd289b8525fd23a5c365ec369185f2966529c2 # 2.3.0
-        with:
-          dry-run: ${{ inputs.dry-run || false }}
         env:
           SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
           SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
           # The wp.org slug is not the repository name, which the action would otherwise use.
           SLUG: frontend-uploader
-          # Empty on release, where the action derives the version from the tag.
-          VERSION: ${{ inputs.version }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,39 @@
+name: Deploy to WordPress.org
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to deploy, e.g. 1.3.5. Must match a tag and the readme.txt stable tag.'
+        required: true
+        type: string
+      dry-run:
+        description: 'Run without committing to SVN'
+        required: false
+        default: true
+        type: boolean
+
+jobs:
+  deploy:
+    name: Deploy
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.version || github.ref }}
+
+      - name: Deploy to WordPress.org
+        uses: 10up/action-wordpress-plugin-deploy@54bd289b8525fd23a5c365ec369185f2966529c2 # 2.3.0
+        with:
+          dry-run: ${{ inputs.dry-run || false }}
+        env:
+          SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
+          SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
+          # The wp.org slug is not the repository name, which the action would otherwise use.
+          SLUG: frontend-uploader
+          # Empty on release, where the action derives the version from the tag.
+          VERSION: ${{ inputs.version }}


### PR DESCRIPTION
Adds `10up/action-wordpress-plugin-deploy` so releases publish to the plugin directory, plus a `.distignore` so development files stay out of the package.

## ⚠️ The plugin is currently closed on WordPress.org

Worth knowing before this is merged — the workflow cannot publish until this changes:

```
"error": "closed",
"description": "This plugin has been closed as of July 22, 2021 and is not available for download.
                Reason: Security Issue.",
"closed_date": "2021-07-22",
"reason": "security-issue"
```

The SVN repo still exists and its newest tag is `1.3.4`, so the plumbing here is correct and ready — but a deploy will not make the plugin available again on its own. Reopening goes through the Plugin Review team. This is presumably the backdrop for the hardening in #94/#95; those may be what the review team needs to see.

## What's here

**`.github/workflows/deploy.yml`** — runs on `release: published`. Both actions are pinned by commit SHA (`10up/action-wordpress-plugin-deploy` 2.3.0, `actions/checkout` v7.0.1) rather than floating tags. No workflow inputs, so the only expressions are the two `secrets` lookups.

**`SLUG` is set explicitly**, which matters: the action defaults to the repository name, and

| slug | `plugins.svn.wordpress.org` |
|---|---|
| `frontend-uploader` | 200 ✅ |
| `wp-frontend-uploader` | 404 ❌ |

Without it, every deploy would target a repo that does not exist.

**`.distignore`** — verified by running the action's exact rsync invocation locally. The resulting package is:

```
frontend-uploader.php
readme.txt
screenshot-1..4.png
lib/         (137 files)
languages/   (22 files)
```

and it drops `tests/`, `bin/`, `composer.json`, `composer.lock`, `phpunit.xml`, `.travis.yml`, `readme.md`, `.github/` and the nested `lib/php/settings-api/` dev files.

`screenshot-*.png` are deliberately **kept**: SVN `assets/` contains only `banner-772x250.png`, so wp.org serves this plugin's screenshots from trunk. Excluding them would blank the screenshots on the listing.

## Before the first deploy

1. Add the `SVN_USERNAME` and `SVN_PASSWORD` repository secrets (a WordPress.org account with commit access to the plugin).
2. `readme.txt` `Stable tag:` and the plugin header `Version:` must both match the release tag — the action does not reconcile them. Both currently say `1.3.4`.

## Not included

No manual dry-run trigger. It was in the first revision, but it needed the `inputs` context, which is only populated for `workflow_dispatch` — and the action runs `if $INPUT_DRY_RUN`, executing the value as a shell command, so an expression rendering empty is a syntax error rather than a falsy default. Releases are the real trigger, and a dry run cannot verify much while the plugin is closed. Easy to add later if it earns its place.

No build step, since the plugin ships its sources directly. No `.wordpress-org/` assets directory — the existing SVN `assets/` is untouched, so the banner stays as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)