### PR TITLE
Restrict append_to_post to the layouts that create the post

### DIFF
--- a/frontend-uploader.php
+++ b/frontend-uploader.php
@@ -448,7 +448,19 @@ class Frontend_Uploader {
 		// Bail if request is failed,
 		if ( ! $success || !isset( $_POST[ 'append_to_post' ] ) || !$_POST['append_to_post'] )
 			return;
+
+		// phpcs:ignore WordPress.Security.NonceVerification.Missing -- upload_content() verifies FU_NONCE before dispatching here.
+		$layout = isset( $_POST['form_layout'] ) && is_scalar( $_POST['form_layout'] ) ? sanitize_text_field( wp_unslash( $_POST['form_layout'] ) ) : '';
+
+		if ( ! in_array( $layout, array( 'post_image', 'post_media' ), true ) ) {
+			return;
+		}
+
 		$post = get_post( $post_id );
+
+		if ( ! $post instanceof WP_Post ) {
+			return;
+		}
 
 		$attachments_html = "\n";
 

--- a/frontend-uploader.php
+++ b/frontend-uploader.php
@@ -456,22 +456,27 @@ class Frontend_Uploader {
 			return;
 		}
 
+		$attachments_html = '';
+
+		foreach( (array) $media_ids as $media_id ) {
+			$attachments_html .= wp_get_attachment_image( $media_id, 'full' );
+		}
+
+		// Nothing rendered (no file, or a non-image attachment) -- don't re-save the post to append a bare newline.
+		if ( '' === $attachments_html ) {
+			return;
+		}
+
 		$post = get_post( $post_id );
 
 		if ( ! $post instanceof WP_Post ) {
 			return;
 		}
 
-		$attachments_html = "\n";
-
-		foreach( (array) $media_ids as $media_id ) {
-			$attachments_html .= wp_get_attachment_image( $media_id, 'full' );
-		}
-
 		// add wp_kses_allowed_html filter just in time before we save post
 		add_filter( 'wp_kses_allowed_html', array( $this, 'wp_kses_add_srcset' ), 10, 2 );
 
-		$post->post_content .= $attachments_html;
+		$post->post_content .= "\n" . $attachments_html;
 
 		return wp_update_post( $post, true );
 	}


### PR DESCRIPTION
Found during a security review of the plugin.

## The problem

`_maybe_insert_images_into_post()` is hooked on `fu_after_upload` (`:125`), which `_upload_files()` fires at `:435` for **every** layout, with whatever parent post id the request supplied. The callback read `append_to_post` straight from `$_POST` with no check on the layout — so the `media`/`image` layouts reached it too, and there `$post_id` is a pre-existing post rather than the submission the request just created. The form only ever prints that hidden field for `post_media`/`post_image` (`:1442`), so nothing but the handler itself constrained it.

The parent nonce printed at `:1324` authorizes *attaching media* to a post — attachments stay `private` pending moderation. It does not authorize *rewriting that post's content*, and this turned one into the other with no moderation step.

Because that nonce is printed publicly on any page hosting `[fu-upload-form]` (`post_id` defaults to `get_the_ID()`), the path was reachable unauthenticated:

1. Load the page, harvest `fu_nonce` and `fu_parent_nonce`.
2. POST to `admin-ajax.php` with `action=upload_ugc`, both nonces, `form_layout=media`, `post_ID=<that page's id>`, `append_to_post=1`, and a `files[]` part.
3. `is_authorized_parent_post()` passes on the public nonce, and the live post gets rewritten.

Two impacts:

- **Content injection** — attacker-uploaded images appended to the published post body.
- **Destructive re-save, no valid file needed** — a multipart request with an *empty* file part yields `UPLOAD_ERR_NO_FILE`, which `:361` skips, leaving `$errors` empty and `$success` true. The hook still fires. The post is re-saved with only `"\n"` appended, but since the request is unauthenticated `kses_init_filters()` is active, so `wp_insert_post()`'s `sanitize_post( …, 'db' )` runs `wp_filter_post_kses` over the **entire pre-existing content** — silently stripping admin-authored `<script>`, `<iframe>`, `<style>`. Repeatable at will against every post or page displaying an upload form.

## The fix

Gate the append on the post-creating layouts, where `$post_id` is this request's own submission. Behavior for the intended `post_image`/`post_media` case is unchanged.

Also guards the `get_post()` result: with `append_to_post=1` and no `post_ID`, the callback previously hit `get_post( 0 ) === null` and fataled on PHP 8 (`Attempt to assign property "post_content" on null`) — an unauthenticated HTTP 500 on the same path.

## Testing

`php -l` passes. The suite has no coverage of this path (one test total) and doesn't run here — no `vendor/` phpunit and no WP test library present — so this was verified by reading, not by executing tests.

## Not included

The review also turned up admin-screen robustness issues in `lib/views/manage-ugc-*.tpl.php` — an array-valued `$_GET['deleted']` fataling in `number_format_i18n()`, and an undefined-key warning on `$messages[ $_GET['message'] ]`. Those need an authenticated moderator and aren't security findings; they belong with the remaining `is_scalar()` guards rather than in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)