### PR TITLE
Bump plugin version to 1.3.5

### DIFF
--- a/frontend-uploader.php
+++ b/frontend-uploader.php
@@ -3,7 +3,7 @@
 Plugin Name: Frontend Uploader
 Description: Allow your visitors to upload content and moderate it.
 Author: Rinat Khaziev, Daniel Bachhuber
-Version: 1.3.4
+Version: 1.3.5
 Author URI: https://rinat.dev/
 Text Domain: frontend-uploader
 Requires at least: 4.6
@@ -28,7 +28,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 */
 
 // Define consts and bootstrap and dependencies
-define( 'FU_VERSION', '1.3.4' );
+define( 'FU_VERSION', '1.3.5' );
 define( 'FU_ROOT' , dirname( __FILE__ ) );
 define( 'FU_FILE_PATH' , FU_ROOT . '/' . basename( __FILE__ ) );
 define( 'FU_URL' , plugins_url( '/', __FILE__ ) );

--- a/readme.txt
+++ b/readme.txt
@@ -4,8 +4,8 @@ Donate link: https://www.paypal.me/RinatK
 Tags: frontend, image, images, media, uploader, upload, video, audio, photo, photos, picture, pictures, file, user generated content, ugc, frontend upload
 Requires at least: 4.6
 Requires PHP: 7.2
-Tested up to: 5.9
-Stable tag: 1.3.4
+Tested up to: 7.1
+Stable tag: 1.3.5
 License: GPLv2 or later
 
 This plugin allows your visitors to upload User Generated Content (media and posts/custom-post-types with media).
@@ -399,6 +399,11 @@ function my_fu_upload_result( $layout, $result ) {
 }`
 
 == Changelog ==
+
+= 1.3.5 (Sep 2, 2026) =
+* Improve upload and moderation request handling.
+* Prevent uploaded images from being appended to existing posts.
+* Fix PHP 8 error handling when media sideloading fails.
 
 = 1.3.4 (Jan 26, 2022) =
 * Bugfix: the new allow type logic resulted in an infinite loop in some cases


### PR DESCRIPTION
## Summary

- bump the plugin header and FU_VERSION constant to 1.3.5
- update the WordPress.org stable tag and tested-up-to version to 7.1
- add the 1.3.5 changelog entry

## Verification

- composer validate --no-check-publish --no-interaction
- php -l frontend-uploader.php (passes with two pre-existing deprecation notices)
- git diff --check
- exact release metadata assertions
