### PR TITLE
Add meaningful integration test coverage

### DIFF
--- a/frontend-uploader.php
+++ b/frontend-uploader.php
@@ -1097,7 +1097,15 @@ class Frontend_Uploader {
 
 		extract( $atts );
 
-		$role = in_array( $role, array( 'meta', 'title', 'description', 'author', 'internal', 'content' ), true ) ? $role : 'meta';
+		if ( 'file' === $type ) {
+			$role = 'file';
+			if ( '' === $name ) {
+				$name         = 'files';
+				$atts['name'] = $name;
+			}
+		}
+
+		$role = in_array( $role, array( 'meta', 'title', 'description', 'author', 'internal', 'content', 'file' ), true ) ? $role : 'meta';
 		$name = sanitize_text_field( $name );
 		// Add the field to fields map
 		$this->form_fields[$role][] = $name;
@@ -1124,7 +1132,7 @@ class Frontend_Uploader {
 		// Allow multiple file upload by default.
 		// To do so, we need to add array notation to name field: []
 		if ( !strpos( $name, '[]' ) && $type === 'file' )
-			$name = 'files' . '[]';
+			$name .= '[]';
 
 		$input = $this->html->input( $type, $name, $value, $atts );
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -29,3 +29,5 @@ function frontend_uploader_manually_load_plugin() {
 tests_add_filter( 'muplugins_loaded', 'frontend_uploader_manually_load_plugin' );
 
 require $_tests_dir . '/includes/bootstrap.php';
+
+require_once __DIR__ . '/includes/class-frontend-uploader-test-case.php';

--- a/tests/includes/class-frontend-uploader-test-case.php
+++ b/tests/includes/class-frontend-uploader-test-case.php
@@ -1,0 +1,77 @@
+<?php
+/**
+ * Shared state management for Frontend Uploader integration tests.
+ */
+
+abstract class Frontend_Uploader_Test_Case extends WP_UnitTestCase {
+	protected $fu;
+
+	private $original_files;
+	private $original_get;
+	private $original_post;
+	private $original_request;
+	private $original_shortcodes;
+	private $original_settings;
+	private $original_allowed_mime_types;
+	private $original_form_fields;
+	private $original_global_post;
+	private $had_original_global_post;
+	private $original_is_debug;
+	private $original_user_id;
+
+	public function set_up() {
+		parent::set_up();
+
+		$this->fu                          = $GLOBALS['frontend_uploader'];
+		$this->original_files              = $_FILES;
+		$this->original_get                = $_GET;
+		$this->original_post               = $_POST;
+		$this->original_request            = $_REQUEST;
+		$this->original_shortcodes          = $GLOBALS['shortcode_tags'];
+		$this->original_settings           = $this->fu->settings;
+		$this->original_allowed_mime_types = $this->fu->allowed_mime_types;
+		$this->original_form_fields        = $this->fu->form_fields;
+		$this->had_original_global_post    = array_key_exists( 'post', $GLOBALS );
+		$this->original_global_post        = $this->had_original_global_post ? $GLOBALS['post'] : null;
+		$this->original_is_debug           = $this->fu->is_debug;
+		$this->original_user_id            = get_current_user_id();
+
+		$_FILES           = array();
+		$_GET             = array();
+		$_POST            = array();
+		$_REQUEST         = array();
+		$this->fu->form_fields = array();
+		wp_set_current_user( 0 );
+	}
+
+	public function tear_down() {
+		$_FILES                     = $this->original_files;
+		$_GET                       = $this->original_get;
+		$_POST                      = $this->original_post;
+		$_REQUEST                   = $this->original_request;
+		$GLOBALS['shortcode_tags']  = $this->original_shortcodes;
+		$this->fu->settings         = $this->original_settings;
+		$this->fu->allowed_mime_types = $this->original_allowed_mime_types;
+		$this->fu->form_fields      = $this->original_form_fields;
+		$this->fu->is_debug         = $this->original_is_debug;
+		if ( $this->had_original_global_post ) {
+			$GLOBALS['post'] = $this->original_global_post;
+		} else {
+			unset( $GLOBALS['post'] );
+		}
+		wp_set_current_user( $this->original_user_id );
+
+		parent::tear_down();
+	}
+
+	protected function capture_output( $callback ) {
+		ob_start();
+		try {
+			call_user_func( $callback );
+			return ob_get_clean();
+		} catch ( Throwable $throwable ) {
+			ob_end_clean();
+			throw $throwable;
+		}
+	}
+}

--- a/tests/test-functions.php
+++ b/tests/test-functions.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * Procedural helper tests.
+ */
+
+class Frontend_Uploader_Functions_Test extends Frontend_Uploader_Test_Case {
+	public function test_file_array_normalizes_multiple_uploads() {
+		$_FILES['uploads'] = array(
+			'name'     => array( 'first' => 'one.jpg', 'second' => 'two.jpg' ),
+			'type'     => array( 'first' => 'image/jpeg', 'second' => 'image/jpeg' ),
+			'tmp_name' => array( 'first' => '/tmp/one', 'second' => '/tmp/two' ),
+			'error'    => array( 'first' => 0, 'second' => UPLOAD_ERR_NO_FILE ),
+			'size'     => array( 'first' => 100, 'second' => 0 ),
+		);
+
+		$files = fu_get_file_array();
+
+		$this->assertSame(
+			array(
+				'uploads' => array(
+					'first'  => array(
+						'name'     => 'one.jpg',
+						'type'     => 'image/jpeg',
+						'tmp_name' => '/tmp/one',
+						'error'    => 0,
+						'size'     => 100,
+					),
+					'second' => array(
+						'name'     => 'two.jpg',
+						'type'     => 'image/jpeg',
+						'tmp_name' => '/tmp/two',
+						'error'    => UPLOAD_ERR_NO_FILE,
+						'size'     => 0,
+					),
+				),
+			),
+			$files
+		);
+	}
+
+	public function test_file_array_preserves_single_upload_shape() {
+		$_FILES['upload'] = array(
+			'name'     => 'one.jpg',
+			'type'     => 'image/jpeg',
+			'tmp_name' => '/tmp/one',
+			'error'    => 0,
+			'size'     => 100,
+		);
+
+		$this->assertSame( $_FILES, fu_get_file_array() );
+	}
+}

--- a/tests/test-html-helper.php
+++ b/tests/test-html-helper.php
@@ -1,0 +1,68 @@
+<?php
+/**
+ * HTML helper behavior tests.
+ */
+
+class Frontend_Uploader_Html_Helper_Test extends Frontend_Uploader_Test_Case {
+	public function test_element_escapes_content_and_rejects_disallowed_tags() {
+		$helper = new Html_Helper();
+		$element = $helper->element( 'p', 'Unsafe <script>alert(1)</script>' );
+
+		$this->assertStringContainsString( 'Unsafe &lt;script&gt;alert(1)&lt;/script&gt;', $element );
+		$this->assertStringNotContainsString( '<script>', $element );
+		$this->assertNull( $helper->element( 'script', 'alert(1)' ) );
+	}
+
+	public function test_attributes_drop_event_handlers_and_unpaired_aria_required() {
+		$helper     = new Html_Helper();
+		$attributes = $helper->_format_attributes(
+			array(
+				'class'         => 'field<script>',
+				'onclick'       => 'alert(1)',
+				'required'      => false,
+				'aria-required' => 'true',
+			)
+		);
+
+		$this->assertStringContainsString( "class='field&lt;script&gt;'", $attributes );
+		$this->assertStringNotContainsString( 'onclick', $attributes );
+		$this->assertStringNotContainsString( 'required', $attributes );
+	}
+
+	public function test_required_attribute_keeps_aria_required() {
+		$helper     = new Html_Helper();
+		$attributes = $helper->_format_attributes(
+			array(
+				'required'      => 'required',
+				'aria-required' => 'true',
+			)
+		);
+
+		$this->assertStringContainsString( "required='required'", $attributes );
+		$this->assertStringContainsString( "aria-required='true'", $attributes );
+	}
+
+	public function test_select_marks_the_requested_default() {
+		$helper = new Html_Helper();
+		$select = $helper->input(
+			'select',
+			'colour',
+			array(
+				'blue' => 'Blue',
+				'red'  => 'Red',
+			),
+			array( 'default' => 'red' )
+		);
+
+		$this->assertStringContainsString( '<select name="colour">', $select );
+		$this->assertStringContainsString( "value='red' selected='selected'", $select );
+		$this->assertStringNotContainsString( "value='blue' selected='selected'", $select );
+	}
+
+	public function test_link_requires_a_valid_url_and_escapes_the_title() {
+		$helper = new Html_Helper();
+
+		$this->assertNull( $helper->a( 'javascript:alert(1)', 'Unsafe' ) );
+		$this->assertStringContainsString( 'Safe &lt;title&gt;', $helper->a( 'https://example.com/', 'Safe <title>' ) );
+	}
+}

--- a/tests/test-main.php
+++ b/tests/test-main.php
@@ -3,13 +3,7 @@
  * Frontend Uploader integration tests.
  */
 
-class Frontend_Uploader_UnitTestCase extends WP_UnitTestCase {
-	protected $fu;
-
-	public function set_up() {
-		parent::set_up();
-		$this->fu = $GLOBALS['frontend_uploader'];
-	}
+class Frontend_Uploader_UnitTestCase extends Frontend_Uploader_Test_Case {
 
 	public function test_plugin_is_loaded() {
 		$this->assertInstanceOf( Frontend_Uploader::class, $this->fu );

--- a/tests/test-rendering.php
+++ b/tests/test-rendering.php
@@ -1,0 +1,139 @@
+<?php
+/**
+ * Frontend form and response rendering tests.
+ */
+
+class Frontend_Uploader_Rendering_Test extends Frontend_Uploader_Test_Case {
+	public function test_notice_html_escapes_message_and_class() {
+		$notice = $this->fu->_notice_html( '<script>alert(1)</script>', 'success" onclick="alert(1)' );
+
+		$this->assertStringNotContainsString( '<script>', $notice );
+		$this->assertStringNotContainsString( 'onclick="alert(1)"', $notice );
+		$this->assertStringContainsString( '&lt;script&gt;alert(1)&lt;/script&gt;', $notice );
+	}
+
+	public function test_response_notice_renders_known_error_without_untrusted_markup() {
+		$output = $this->capture_output(
+			function () {
+				$this->fu->_display_response_notices(
+					array(
+						'response' => 'fu-error',
+						'errors'   => array(
+							'fu-error-media' => array( '<img src=x onerror=alert(1)>' ),
+						),
+					)
+				);
+			}
+		);
+
+		$this->assertStringContainsString( 'There was an error with your submission', $output );
+		$this->assertStringContainsString( 'failure', $output );
+		$this->assertStringNotContainsString( '<img', $output );
+		$this->assertStringNotContainsString( 'onerror=', $output );
+	}
+
+	public function test_post_media_form_contains_scoped_parent_nonce_and_field_map() {
+		$page_id         = self::factory()->post->create( array( 'post_type' => 'page' ) );
+		$GLOBALS['post'] = get_post( $page_id );
+		setup_postdata( $GLOBALS['post'] );
+
+		$this->fu->settings = array_merge(
+			(array) $this->fu->settings,
+			array(
+				'enable_recaptcha_protection' => 'off',
+				'suppress_default_fields'      => 'off',
+			)
+		);
+
+		$form = $this->fu->upload_form(
+			array(
+				'form_layout'   => 'post_media',
+				'post_id'       => $page_id,
+				'append_to_post' => true,
+			)
+		);
+
+		$this->assertMatchesRegularExpression( '/name="fu_parent_nonce" value="([^"]+)"/', $form );
+		preg_match( '/name="fu_parent_nonce" value="([^"]+)"/', $form, $nonce_match );
+		$this->assertNotFalse( wp_verify_nonce( $nonce_match[1], FU_PARENT_NONCE . '-' . $page_id ) );
+		$this->assertMatchesRegularExpression( '/<input(?=[^>]*name="append_to_post")(?=[^>]*value="1")[^>]*>/', $form );
+
+		preg_match( '/name="ff" value="([a-f0-9]+)"/', $form, $hash_match );
+		$this->assertNotEmpty( $hash_match[1] );
+		$fields = $this->fu->_get_fields_for_form( $page_id, $hash_match[1] );
+		$this->assertIsArray( $fields );
+		$this->assertContains( 'post_type', $fields['internal'] );
+		$this->assertContains( 'append_to_post', $fields['internal'] );
+		$this->assertArrayHasKey( 'file', $fields, var_export( $fields, true ) );
+		$this->assertContains( 'files', $fields['file'] );
+
+		wp_reset_postdata();
+	}
+
+	public function test_custom_file_shortcode_is_persisted_as_the_rendered_file_field() {
+		$page_id         = self::factory()->post->create( array( 'post_type' => 'page' ) );
+		$GLOBALS['post'] = get_post( $page_id );
+		setup_postdata( $GLOBALS['post'] );
+
+		$this->fu->settings = array_merge(
+			(array) $this->fu->settings,
+			array( 'enable_recaptcha_protection' => 'off' )
+		);
+
+		$form = $this->fu->upload_form(
+			array(
+				'form_layout'            => 'media',
+				'post_id'                => $page_id,
+				'suppress_default_fields' => true,
+			),
+			'[input type="file" name="my-file"]'
+		);
+
+		$this->assertStringContainsString( 'name="my-file[]"', $form );
+		preg_match( '/name="ff" value="([a-f0-9]+)"/', $form, $hash_match );
+		$fields = $this->fu->_get_fields_for_form( $page_id, $hash_match[1] );
+
+		$this->assertSame( array( 'my-file' ), $fields['file'] );
+		$this->assertNotContains( 'my-file', isset( $fields['meta'] ) ? $fields['meta'] : array() );
+
+		wp_reset_postdata();
+	}
+
+	public function test_unnamed_file_shortcode_uses_the_default_files_name() {
+		$this->fu->settings = array_merge(
+			(array) $this->fu->settings,
+			array( 'enable_recaptcha_protection' => 'off' )
+		);
+
+		$form = $this->fu->upload_form(
+			array(
+				'form_layout'            => 'media',
+				'suppress_default_fields' => true,
+			),
+			'[input type="file"]'
+		);
+
+		$this->assertStringContainsString( 'name="files[]"', $form );
+	}
+
+	public function test_image_form_without_parent_omits_parent_nonce_and_append_flag() {
+		$this->fu->settings = array_merge(
+			(array) $this->fu->settings,
+			array(
+				'enable_recaptcha_protection' => 'off',
+				'suppress_default_fields'      => 'off',
+			)
+		);
+
+		$form = $this->fu->upload_form(
+			array(
+				'form_layout' => 'image',
+				'post_id'     => 0,
+			)
+		);
+
+		$this->assertStringNotContainsString( 'name="fu_parent_nonce"', $form );
+		$this->assertStringNotContainsString( 'name="append_to_post"', $form );
+		$this->assertStringContainsString( 'name="files[]"', $form );
+	}
+}

--- a/tests/test-security.php
+++ b/tests/test-security.php
@@ -1,0 +1,92 @@
+<?php
+/**
+ * Upload and moderation security tests.
+ */
+
+class Frontend_Uploader_Security_Test extends Frontend_Uploader_Test_Case {
+	/**
+	 * @dataProvider suspicious_payload_provider
+	 */
+	public function test_suspicious_file_payloads_are_detected( $payload ) {
+		$this->assertGreaterThan( 0, $this->fu->_invoke_paranoia_on_file_contents( $payload ) );
+	}
+
+	public function suspicious_payload_provider() {
+		return array(
+			'php opening tag' => array( '<?php echo "unsafe";' ),
+			'eval call'       => array( 'eval ( $payload );' ),
+			'base64 decode'   => array( 'base64_decode( $payload )' ),
+			'gzinflate call'  => array( 'gzinflate( $payload )' ),
+			'gzuncompress'    => array( 'gzuncompress( $payload )' ),
+		);
+	}
+
+	public function test_benign_file_payload_is_not_flagged() {
+		$this->assertSame( 0, $this->fu->_invoke_paranoia_on_file_contents( 'A normal image caption.' ) );
+	}
+
+	public function test_non_string_file_payload_is_not_flagged() {
+		$this->assertSame( 0, $this->fu->_invoke_paranoia_on_file_contents( array( 'not', 'a', 'file' ) ) );
+	}
+
+	public function test_executable_extensions_are_removed_from_allowed_mime_types() {
+		$core_mimes = get_allowed_mime_types();
+		$jpeg_key   = array_search( 'image/jpeg', $core_mimes, true );
+		$warnings   = array();
+
+		$this->assertNotFalse( $jpeg_key );
+
+		$this->fu->settings['enabled_files'] = array(
+			$jpeg_key => 'image/jpeg',
+			'php'     => 'text/x-php',
+			'svg'     => 'image/svg+xml',
+		);
+
+		set_error_handler(
+			function ( $severity, $message ) use ( &$warnings ) {
+				$warnings[] = $message;
+				return true;
+			}
+		);
+
+		try {
+			$allowed = $this->fu->_get_mime_types();
+		} finally {
+			restore_error_handler();
+		}
+
+		$this->assertSame( 'image/jpeg', $allowed[ $jpeg_key ] );
+		$this->assertArrayNotHasKey( 'php', $allowed );
+		$this->assertArrayNotHasKey( 'svg', $allowed );
+		$this->assertCount( 1, $warnings );
+		$this->assertStringContainsString( 'blocks uploads of executable file types', implode( ' ', $warnings ) );
+	}
+
+	public function test_moderation_nonce_is_scoped_to_action_and_post() {
+		$post_id = self::factory()->post->create();
+		$action  = $this->fu->get_moderation_nonce_action( 'approve', $post_id );
+		$nonce   = wp_create_nonce( $action );
+
+		$this->assertNotFalse( wp_verify_nonce( $nonce, $action ) );
+		$this->assertFalse( wp_verify_nonce( $nonce, $this->fu->get_moderation_nonce_action( 'delete', $post_id ) ) );
+		$this->assertFalse( wp_verify_nonce( $nonce, $this->fu->get_moderation_nonce_action( 'approve', $post_id + 1 ) ) );
+	}
+
+	public function test_only_configured_registered_post_types_are_allowed() {
+		register_post_type( 'fu_book', array( 'public' => true ) );
+		try {
+			$this->fu->settings['enabled_post_types'] = array(
+				'post'    => 'Posts',
+				'fu_book' => 'Books',
+				'missing' => 'Missing',
+			);
+
+			$this->assertTrue( $this->fu->is_allowed_post_type( 'post' ) );
+			$this->assertTrue( $this->fu->is_allowed_post_type( 'fu_book' ) );
+			$this->assertFalse( $this->fu->is_allowed_post_type( 'page' ) );
+			$this->assertFalse( $this->fu->is_allowed_post_type( 'missing' ) );
+		} finally {
+			unregister_post_type( 'fu_book' );
+		}
+	}
+}

--- a/tests/test-submissions.php
+++ b/tests/test-submissions.php
@@ -1,0 +1,100 @@
+<?php
+/**
+ * Post-submission integration tests.
+ */
+
+class Frontend_Uploader_Submissions_Test extends Frontend_Uploader_Test_Case {
+	public function set_up() {
+		parent::set_up();
+
+		$this->fu->settings = array_merge(
+			(array) $this->fu->settings,
+			array(
+				'auto_approve_user_files' => 'off',
+				'auto_approve_any_files'  => 'off',
+				'enabled_post_types'      => array( 'post' => 'Posts' ),
+			)
+		);
+	}
+
+	public function test_post_submission_is_private_and_sanitized() {
+		$category_id = self::factory()->category->create();
+		$_POST       = array(
+			'post_type'     => 'post',
+			'post_title'    => '<b>Submission title</b>',
+			'post_content'  => '<script>alert(1)</script><p>Allowed content</p>',
+			'post_category' => $category_id . ',not-a-number',
+			'post_author'   => 'Visitor <script>alert(1)</script>',
+		);
+
+		$result = $this->fu->_upload_post();
+		$post   = get_post( $result['post_id'] );
+
+		$this->assertTrue( $result['success'] );
+		$this->assertInstanceOf( WP_Post::class, $post );
+		$this->assertSame( 'private', $post->post_status );
+		$this->assertSame( 'Submission title', $post->post_title );
+		$this->assertStringNotContainsString( '<script', $post->post_content );
+		$this->assertStringContainsString( '<p>Allowed content</p>', $post->post_content );
+		$this->assertContains( $category_id, wp_get_post_categories( $post->ID ) );
+		$this->assertSame( 0, (int) $post->post_author );
+		$this->assertSame( 'Visitor', get_post_meta( $post->ID, 'author_name', true ) );
+	}
+
+	public function test_auto_approved_submission_is_published() {
+		$this->fu->settings['auto_approve_any_files'] = 'on';
+		$_POST = array(
+			'post_type'  => 'post',
+			'post_title' => 'Published submission',
+		);
+
+		$result = $this->fu->_upload_post();
+
+		$this->assertTrue( $result['success'] );
+		$this->assertSame( 'publish', get_post_status( $result['post_id'] ) );
+	}
+
+	public function test_non_scalar_submission_values_are_not_persisted() {
+		$_POST = array(
+			'post_type'    => array( 'page' ),
+			'post_title'   => array( 'Unsafe title' ),
+			'post_content' => array( '<p>Unsafe content</p>' ),
+			'post_author'  => array( 'administrator' ),
+		);
+
+		$result = $this->fu->_upload_post();
+		$post   = get_post( $result['post_id'] );
+
+		$this->assertTrue( $result['success'] );
+		$this->assertSame( 'post', $post->post_type );
+		$this->assertSame( 'Untitled post submission', $post->post_title );
+		$this->assertSame( '', $post->post_content );
+		$this->assertSame( '', get_post_meta( $post->ID, 'author_name', true ) );
+	}
+
+	public function test_disallowed_post_type_falls_back_to_post() {
+		register_post_type( 'fu_book', array( 'public' => true ) );
+		try {
+			$_POST = array(
+				'post_type'  => 'fu_book',
+				'post_title' => 'Book submission',
+			);
+
+			$result = $this->fu->_upload_post();
+
+			$this->assertSame( 'post', get_post_type( $result['post_id'] ) );
+		} finally {
+			unregister_post_type( 'fu_book' );
+		}
+	}
+
+	public function test_auto_approval_for_logged_in_users_requires_the_setting() {
+		$user_id = self::factory()->user->create( array( 'role' => 'subscriber' ) );
+		wp_set_current_user( $user_id );
+
+		$this->assertFalse( $this->fu->_is_public() );
+
+		$this->fu->settings['auto_approve_user_files'] = 'on';
+		$this->assertTrue( $this->fu->_is_public() );
+	}
+}

--- a/tests/test-uploads.php
+++ b/tests/test-uploads.php
@@ -1,0 +1,76 @@
+<?php
+/**
+ * File-upload behavior tests.
+ */
+
+class Frontend_Uploader_Uploads_Test extends Frontend_Uploader_Test_Case {
+	public function test_no_files_is_a_successful_no_op() {
+		$this->assertSame(
+			array(
+				'success'   => true,
+				'media_ids' => array(),
+				'errors'    => array(),
+			),
+			$this->fu->_upload_files()
+		);
+	}
+
+	public function test_empty_file_input_is_a_successful_no_op() {
+		$_FILES['upload'] = array(
+			'name'     => 'empty.jpg',
+			'type'     => 'image/jpeg',
+			'tmp_name' => '',
+			'error'    => UPLOAD_ERR_NO_FILE,
+			'size'     => 0,
+		);
+
+		$result = $this->fu->_upload_files();
+
+		$this->assertTrue( $result['success'] );
+		$this->assertSame( array(), $result['media_ids'] );
+		$this->assertSame( array(), $result['errors'] );
+		$this->assertFalse( has_filter( 'upload_mimes', array( $this->fu, '_get_mime_types' ) ) );
+	}
+
+	public function test_server_upload_error_is_reported_and_filter_is_removed() {
+		$_FILES['upload'] = array(
+			'name'     => '../broken.jpg',
+			'type'     => 'image/jpeg',
+			'tmp_name' => '',
+			'error'    => UPLOAD_ERR_INI_SIZE,
+			'size'     => 0,
+		);
+
+		$result = $this->fu->_upload_files();
+
+		$this->assertFalse( $result['success'] );
+		$this->assertSame( 'broken.jpg', $result['errors']['fu-error-media'][0]['name'] );
+		$this->assertSame( UPLOAD_ERR_INI_SIZE, $result['errors']['fu-error-media'][0]['code'] );
+		$this->assertFalse( has_filter( 'upload_mimes', array( $this->fu, '_get_mime_types' ) ) );
+	}
+
+	public function test_suspicious_file_is_rejected_before_media_creation() {
+		$tmp_name = wp_tempnam( 'suspicious.jpg' );
+		file_put_contents( $tmp_name, '<?php eval( base64_decode( $payload ) );' );
+
+		try {
+			$this->fu->allowed_mime_types = array( mime_content_type( $tmp_name ) );
+			$_FILES['upload'] = array(
+				'name'     => '../../suspicious.jpg',
+				'type'     => 'image/jpeg',
+				'tmp_name' => $tmp_name,
+				'error'    => 0,
+				'size'     => filesize( $tmp_name ),
+			);
+
+			$result = $this->fu->_upload_files();
+
+			$this->assertFalse( $result['success'] );
+			$this->assertSame( array(), $result['media_ids'] );
+			$this->assertSame( 'suspicious.jpg', $result['errors']['fu-suspicious-file'][0]['name'] );
+			$this->assertFalse( has_filter( 'upload_mimes', array( $this->fu, '_get_mime_types' ) ) );
+		} finally {
+			unlink( $tmp_name );
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- replace the four smoke-level PHPUnit checks with 36 WordPress integration tests for submissions, uploads, security checks, rendering, nonces, MIME filtering, request sanitization, and HTML helpers
- add shared test-state isolation for request globals, plugin settings, users, post globals, and dynamically registered shortcode handlers
- restore the documented `file` shortcode-field role after regression tests showed custom upload fields were persisted as metadata
- preserve custom file input names while retaining the backward-compatible `files[]` fallback for unnamed fields

## Coverage

Measured with Xdebug 3.5.3 on PHP 8.5.10 and WordPress 7.1:

| Scope | Before | After |
| --- | ---: | ---: |
| Tests | 4 | 36 |
| Assertions | 5 | 95 |
| Methods | 2/107 (1.87%) | 17/107 (15.89%) |
| Lines | 33/1,503 (2.20%) | 458/1,510 (30.33%) |
| `Frontend_Uploader` lines | 0/755 (0%) | 367/762 (48.16%) |
| `Html_Helper` lines | 33/103 (32.04%) | 75/103 (72.82%) |

The untouched bundled settings API and admin list-table classes remain at 0%; the new tests focus on the plugin's user-facing upload and submission behavior.

## Testing

- `composer validate --strict` passed inside the isolated PHP 8.0 `wp-env`
- `composer php:compatibility` passed across 12 production PHP files on PHP 8.0.30 and PHP 8.5.10
- `composer test` passed on PHP 8.0.30: 21 files linted; PHPUnit `OK (36 tests, 95 assertions)`
- `composer test` passed on PHP 8.5.10: 21 files linted; PHPUnit `OK (36 tests, 95 assertions)`
- focused regression tests were run red/green for custom file-field mapping and the unnamed `files[]` fallback
- independent review found no remaining Critical or Important issues
