### PR TITLE
Restore the guest author field

### DIFF
--- a/frontend-uploader.php
+++ b/frontend-uploader.php
@@ -410,10 +410,12 @@ class Frontend_Uploader {
 			// Trying to upload the file
 			$upload_id = media_handle_sideload( $m, (int) $post_id, $post_overrides['post_title'], $post_overrides );
 
-			if ( !is_wp_error( $upload_id ) )
+			if ( !is_wp_error( $upload_id ) ) {
 				$media_ids[] = $upload_id;
-			else
+				$this->_save_guest_author_name( $upload_id );
+			} else {
 				$errors['fu-error-media'][] = $k['name'];
+			}
 		}
 
 		remove_filter( 'upload_mimes', array( $this, '_get_mime_types' ), 999 );
@@ -427,7 +429,6 @@ class Frontend_Uploader {
 		if ( $success ) {
 			foreach ( $media_ids as $media_id ) {
 				$this->_save_post_meta_fields( $media_id );
-				$this->_save_guest_author_name( $media_id );
 			}
 		}
 

--- a/frontend-uploader.php
+++ b/frontend-uploader.php
@@ -427,6 +427,7 @@ class Frontend_Uploader {
 		if ( $success ) {
 			foreach ( $media_ids as $media_id ) {
 				$this->_save_post_meta_fields( $media_id );
+				$this->_save_guest_author_name( $media_id );
 			}
 		}
 

--- a/frontend-uploader.php
+++ b/frontend-uploader.php
@@ -1404,6 +1404,18 @@ class Frontend_Uploader {
 			}
 		}
 
+		// Show the optional guest byline even when the other default fields are suppressed.
+		if ( isset( $this->settings['show_author'] ) && 'on' === $this->settings['show_author'] ) {
+			echo $this->shortcode_content_parser( array(
+					'type' => 'text',
+					'role' => 'author',
+					'name' => 'post_author',
+					'id' => 'ug_post_author',
+					'class' => '',
+					'description' => __( 'Author', 'frontend-uploader' ),
+				), null, 'input' );
+		}
+
 		// Parse nested shortcodes
 		if ( $content )
 			echo do_shortcode( $content );

--- a/frontend-uploader.php
+++ b/frontend-uploader.php
@@ -551,10 +551,6 @@ class Frontend_Uploader {
 			'post_category' => $category,
 		);
 
-		// Stored as meta only: resolving this to a user would let anyone post as an administrator.
-		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.MissingUnslash -- add_post_meta() unslashes; unslashing here too would mangle names like O'Brien.
-		$author = isset( $_POST['post_author'] ) && is_scalar( $_POST['post_author'] ) ? sanitize_text_field( $_POST['post_author'] ) : '';
-
 		$post_array = apply_filters( 'fu_before_create_post', $post_array );
 
 		$post_id = wp_insert_post( $post_array, true );
@@ -569,13 +565,38 @@ class Frontend_Uploader {
 			do_action( 'fu_after_create_post', $post_id );
 
 			$this->_save_post_meta_fields( $post_id );
-			if ( $author )
-				add_post_meta( $post_id, 'author_name', $author );
+			$this->_save_guest_author_name( $post_id );
 		}
 
 		// phpcs:enable WordPress.Security.NonceVerification.Missing
 
 		return array( 'success' => $success, 'post_id' => $post_id, 'errors' => $errors );
+	}
+
+	/**
+	 * Store the submitted guest byline as post metadata.
+	 *
+	 * The value is deliberately not resolved to a WordPress user ID, because an
+	 * anonymous submitter must not be able to select the author account.
+	 *
+	 * @param int $post_id Post or attachment ID.
+	 * @return int|false Meta ID on success, false when there is nothing to store.
+	 */
+	private function _save_guest_author_name( $post_id ) {
+		$post_id = (int) $post_id;
+
+		if ( 0 === $post_id || ! isset( $_POST['post_author'] ) || ! is_scalar( $_POST['post_author'] ) ) {
+			return false;
+		}
+
+		// phpcs:ignore WordPress.Security.NonceVerification.Missing, WordPress.Security.ValidatedSanitizedInput.MissingUnslash -- upload_content() verifies FU_NONCE; add_post_meta() unslashes, so unslashing here too would mangle names like O'Brien.
+		$author = sanitize_text_field( $_POST['post_author'] );
+
+		if ( '' === $author ) {
+			return false;
+		}
+
+		return add_post_meta( $post_id, 'author_name', $author, true );
 	}
 
 	private function _save_post_meta_fields( $post_id = 0 ) {

--- a/tests/test-rendering.php
+++ b/tests/test-rendering.php
@@ -116,6 +116,56 @@ class Frontend_Uploader_Rendering_Test extends Frontend_Uploader_Test_Case {
 		$this->assertStringContainsString( 'name="files[]"', $form );
 	}
 
+	public function test_author_setting_renders_guest_byline_when_default_fields_are_suppressed() {
+		$page_id         = self::factory()->post->create( array( 'post_type' => 'page' ) );
+		$GLOBALS['post'] = get_post( $page_id );
+		setup_postdata( $GLOBALS['post'] );
+
+		$this->fu->settings = array_merge(
+			(array) $this->fu->settings,
+			array(
+				'enable_recaptcha_protection' => 'off',
+				'show_author'                 => 'on',
+			)
+		);
+
+		$form = $this->fu->upload_form(
+			array(
+				'form_layout'            => 'post',
+				'post_id'                => $page_id,
+				'suppress_default_fields' => true,
+			)
+		);
+
+		$this->assertStringContainsString( 'name="post_author"', $form );
+		$this->assertStringContainsString( 'Author</label>', $form );
+
+		preg_match( '/name="ff" value="([a-f0-9]+)"/', $form, $hash_match );
+		$fields = $this->fu->_get_fields_for_form( $page_id, $hash_match[1] );
+		$this->assertSame( array( 'post_author' ), $fields['author'] );
+
+		wp_reset_postdata();
+	}
+
+	public function test_disabled_author_setting_does_not_render_guest_byline() {
+		$this->fu->settings = array_merge(
+			(array) $this->fu->settings,
+			array(
+				'enable_recaptcha_protection' => 'off',
+				'show_author'                 => 'off',
+			)
+		);
+
+		$form = $this->fu->upload_form(
+			array(
+				'form_layout'            => 'post',
+				'suppress_default_fields' => true,
+			)
+		);
+
+		$this->assertStringNotContainsString( 'name="post_author"', $form );
+	}
+
 	public function test_image_form_without_parent_omits_parent_nonce_and_append_flag() {
 		$this->fu->settings = array_merge(
 			(array) $this->fu->settings,

--- a/tests/test-submissions.php
+++ b/tests/test-submissions.php
@@ -69,7 +69,20 @@ class Frontend_Uploader_Submissions_Test extends Frontend_Uploader_Test_Case {
 		$this->assertSame( 'post', $post->post_type );
 		$this->assertSame( 'Untitled post submission', $post->post_title );
 		$this->assertSame( '', $post->post_content );
-		$this->assertSame( '', get_post_meta( $post->ID, 'author_name', true ) );
+		$this->assertFalse( metadata_exists( 'post', $post->ID, 'author_name' ) );
+	}
+
+	public function test_empty_guest_author_is_not_persisted() {
+		$_POST = array(
+			'post_type'   => 'post',
+			'post_title'  => 'Anonymous submission',
+			'post_author' => '   ',
+		);
+
+		$result = $this->fu->_upload_post();
+
+		$this->assertTrue( $result['success'] );
+		$this->assertFalse( metadata_exists( 'post', $result['post_id'], 'author_name' ) );
 	}
 
 	public function test_disallowed_post_type_falls_back_to_post() {

--- a/tests/test-submissions.php
+++ b/tests/test-submissions.php
@@ -18,13 +18,20 @@ class Frontend_Uploader_Submissions_Test extends Frontend_Uploader_Test_Case {
 	}
 
 	public function test_post_submission_is_private_and_sanitized() {
-		$category_id = self::factory()->category->create();
-		$_POST       = array(
+		$category_id      = self::factory()->category->create();
+		$matching_user_id = self::factory()->user->create(
+			array(
+				'user_login'   => 'guest-author-admin',
+				'display_name' => 'Guest Author Admin',
+				'role'         => 'administrator',
+			)
+		);
+		$_POST = array(
 			'post_type'     => 'post',
 			'post_title'    => '<b>Submission title</b>',
 			'post_content'  => '<script>alert(1)</script><p>Allowed content</p>',
 			'post_category' => $category_id . ',not-a-number',
-			'post_author'   => 'Visitor <script>alert(1)</script>',
+			'post_author'   => 'guest-author-admin <script>alert(1)</script>',
 		);
 
 		$result = $this->fu->_upload_post();
@@ -38,7 +45,8 @@ class Frontend_Uploader_Submissions_Test extends Frontend_Uploader_Test_Case {
 		$this->assertStringContainsString( '<p>Allowed content</p>', $post->post_content );
 		$this->assertContains( $category_id, wp_get_post_categories( $post->ID ) );
 		$this->assertSame( 0, (int) $post->post_author );
-		$this->assertSame( 'Visitor', get_post_meta( $post->ID, 'author_name', true ) );
+		$this->assertNotSame( $matching_user_id, (int) $post->post_author );
+		$this->assertSame( 'guest-author-admin', get_post_meta( $post->ID, 'author_name', true ) );
 	}
 
 	public function test_auto_approved_submission_is_published() {

--- a/tests/test-uploads.php
+++ b/tests/test-uploads.php
@@ -4,6 +4,32 @@
  */
 
 class Frontend_Uploader_Uploads_Test extends Frontend_Uploader_Test_Case {
+	private function create_png_upload( $name ) {
+		$tmp_name = wp_tempnam( $name );
+		$png      = base64_decode( 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=' );
+		file_put_contents( $tmp_name, $png );
+
+		return array(
+			'name'     => $name,
+			'type'     => 'image/png',
+			'tmp_name' => $tmp_name,
+			'error'    => 0,
+			'size'     => filesize( $tmp_name ),
+		);
+	}
+
+	private function delete_uploaded_media( $result, $temporary_files ) {
+		foreach ( isset( $result['media_ids'] ) ? $result['media_ids'] : array() as $media_id ) {
+			wp_delete_attachment( $media_id, true );
+		}
+
+		foreach ( $temporary_files as $temporary_file ) {
+			if ( file_exists( $temporary_file ) ) {
+				unlink( $temporary_file );
+			}
+		}
+	}
+
 	public function test_no_files_is_a_successful_no_op() {
 		$this->assertSame(
 			array(
@@ -71,6 +97,66 @@ class Frontend_Uploader_Uploads_Test extends Frontend_Uploader_Test_Case {
 			$this->assertFalse( has_filter( 'upload_mimes', array( $this->fu, '_get_mime_types' ) ) );
 		} finally {
 			unlink( $tmp_name );
+		}
+	}
+
+	public function test_guest_author_is_saved_on_every_successful_attachment() {
+		$first  = $this->create_png_upload( 'first.png' );
+		$second = $this->create_png_upload( 'second.png' );
+		$result = array();
+
+		try {
+			$this->fu->allowed_mime_types = array( 'png' => 'image/png' );
+			$_POST['post_author']          = 'Visitor <script>alert(1)</script>';
+			$_FILES['files']               = array(
+				'name'     => array( $first['name'], $second['name'] ),
+				'type'     => array( $first['type'], $second['type'] ),
+				'tmp_name' => array( $first['tmp_name'], $second['tmp_name'] ),
+				'error'    => array( $first['error'], $second['error'] ),
+				'size'     => array( $first['size'], $second['size'] ),
+			);
+
+			$result = $this->fu->_upload_files();
+
+			$this->assertTrue( $result['success'] );
+			$this->assertCount( 2, $result['media_ids'] );
+			foreach ( $result['media_ids'] as $media_id ) {
+				$this->assertSame( 'Visitor', get_post_meta( $media_id, 'author_name', true ) );
+				$this->assertSame( 0, (int) get_post( $media_id )->post_author );
+			}
+		} finally {
+			$this->delete_uploaded_media( $result, array( $first['tmp_name'], $second['tmp_name'] ) );
+		}
+	}
+
+	public function test_guest_author_is_saved_on_combined_post_and_media_submission() {
+		$upload      = $this->create_png_upload( 'combined.png' );
+		$post_result = array();
+		$file_result = array();
+
+		try {
+			$this->fu->settings['enabled_post_types'] = array( 'post' => 'Posts' );
+			$this->fu->allowed_mime_types             = array( 'png' => 'image/png' );
+			$_POST                                    = array(
+				'post_type'   => 'post',
+				'post_title'  => 'Combined submission',
+				'post_author' => 'Combined Visitor',
+			);
+			$_FILES['files']                          = $upload;
+
+			$post_result = $this->fu->_upload_post();
+			$file_result = $this->fu->_upload_files( $post_result['post_id'] );
+
+			$this->assertTrue( $post_result['success'] );
+			$this->assertTrue( $file_result['success'] );
+			$this->assertSame( 'Combined Visitor', get_post_meta( $post_result['post_id'], 'author_name', true ) );
+			$this->assertCount( 1, $file_result['media_ids'] );
+			$this->assertSame( 'Combined Visitor', get_post_meta( $file_result['media_ids'][0], 'author_name', true ) );
+		} finally {
+			$this->delete_uploaded_media( $file_result, array( $upload['tmp_name'] ) );
+			if ( isset( $post_result['post_id'] ) && ! is_wp_error( $post_result['post_id'] ) ) {
+				wp_delete_post( $post_result['post_id'], true );
+			}
 		}
 	}
 }

--- a/tests/test-uploads.php
+++ b/tests/test-uploads.php
@@ -129,6 +129,32 @@ class Frontend_Uploader_Uploads_Test extends Frontend_Uploader_Test_Case {
 		}
 	}
 
+	public function test_guest_author_is_saved_on_successful_attachment_in_partial_batch() {
+		$upload = $this->create_png_upload( 'successful.png' );
+		$result = array();
+
+		try {
+			$this->fu->allowed_mime_types = array( 'png' => 'image/png' );
+			$_POST['post_author']          = 'Partial Visitor';
+			$_FILES['files']               = array(
+				'name'     => array( $upload['name'], 'failed.png' ),
+				'type'     => array( $upload['type'], 'image/png' ),
+				'tmp_name' => array( $upload['tmp_name'], '' ),
+				'error'    => array( $upload['error'], UPLOAD_ERR_INI_SIZE ),
+				'size'     => array( $upload['size'], 0 ),
+			);
+
+			$result = $this->fu->_upload_files();
+
+			$this->assertFalse( $result['success'] );
+			$this->assertCount( 1, $result['media_ids'] );
+			$this->assertSame( UPLOAD_ERR_INI_SIZE, $result['errors']['fu-error-media'][0]['code'] );
+			$this->assertSame( 'Partial Visitor', get_post_meta( $result['media_ids'][0], 'author_name', true ) );
+		} finally {
+			$this->delete_uploaded_media( $result, array( $upload['tmp_name'] ) );
+		}
+	}
+
 	public function test_guest_author_is_saved_on_combined_post_and_media_submission() {
 		$upload      = $this->create_png_upload( 'combined.png' );
 		$post_result = array();


### PR DESCRIPTION
## Summary

- restore the optional guest author/byline field when the `show_author` setting is enabled, including forms that suppress the other default fields
- store sanitized guest names as `author_name` metadata on submitted posts and every successfully uploaded attachment
- keep WordPress's numeric `post_author` untouched so anonymous submitters cannot select a user account
- add rendering, validation, multi-file upload, and combined post-plus-media regression coverage

## Testing

- PHP 8.0.30: `composer validate --strict`
- PHP 8.0.30: `composer php:compatibility`
- PHP 8.0.30: `composer test` — 42 tests, 117 assertions
- PHP 8.5.10: `composer test` — 42 tests, 117 assertions

Closes #87
